### PR TITLE
fix compile error with gcc13

### DIFF
--- a/kernel/bsp/drivers/npu/aw_nna_galcore/os/gc_hal_kernel_linux.h
+++ b/kernel/bsp/drivers/npu/aw_nna_galcore/os/gc_hal_kernel_linux.h
@@ -337,7 +337,7 @@ gceSTATUS
 _ConvertLogical2Physical(gckOS Os, gctPOINTER Logical, gctUINT32 ProcessID,
                          PLINUX_MDL Mdl, gctPHYS_ADDR_T *Physical);
 
-gctBOOL
+gceSTATUS
 _QuerySignal(gckOS Os, gctSIGNAL Signal);
 
 static inline gctINT

--- a/kernel/bsp/drivers/npu/aw_nna_vip/linux/gc_vip_kernel_allocator.c
+++ b/kernel/bsp/drivers/npu/aw_nna_vip/linux/gc_vip_kernel_allocator.c
@@ -120,7 +120,7 @@ static vip_status_e gckvip_map_user(
     gckvip_dyn_allocate_node_t *node,
     struct page **pages,
     vip_uint32_t num_pages,
-    vip_uint32_t alloc_flag,
+    gckvip_video_mem_alloc_flag_e alloc_flag,
     void **logical
     );
 


### PR DESCRIPTION
```bash
bsp/drivers/npu/aw_nna_vip/linux/gc_vip_kernel_allocator.c:2017:21: error: conflicting types for ‘gckvip_map_user’ due to enum/integer mismatch; have ‘vip_status_e(gckvip_dyn_allocate_node_t *, struct page **, vip_uint32_t,  gckvip_video_mem_alloc_flag_e,  void **)’ {aka ‘enum _vip_status(struct _gckvip_dyn_allocate_node *, struct page **, unsigned int,  enum _gckvip_video_mem_alloc_flag,  void **)’} [-Werror=enum-int-mismatch]
 2017 | static vip_status_e gckvip_map_user(
      |                     ^~~~~~~~~~~~~~~
bsp/drivers/npu/aw_nna_vip/linux/gc_vip_kernel_allocator.c:119:21: note: previous declaration of ‘gckvip_map_user’ with type ‘vip_status_e(gckvip_dyn_allocate_node_t *, struct page **, vip_uint32_t,  vip_uint32_t,  void **)’ {aka ‘enum _vip_status(struct _gckvip_dyn_allocate_node *, struct page **, unsigned int,  unsigned int,  void **)’}
  119 | static vip_status_e gckvip_map_user(
      |                     ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

```bash

bsp/drivers/npu/aw_nna_galcore/os/gc_hal_kernel_os.c:5767:1: error: conflicting types for ‘_QuerySignal’ due to enum/integer mismatch; have ‘gceSTATUS(struct _gckOS *, void *)’ {aka ‘enum _gceSTATUS(struct _gckOS *, void *)’} [-Werror=enum-int-mismatch]
 5767 | _QuerySignal(gckOS Os, gctSIGNAL Signal)
      | ^~~~~~~~~~~~
In file included from bsp/drivers/npu/aw_nna_galcore/os/gc_hal_kernel_os.c:56:
bsp/drivers/npu/aw_nna_galcore/os/gc_hal_kernel_linux.h:341:1: note: previous declaration of ‘_QuerySignal’ with type ‘gctBOOL(struct _gckOS *, void *)’ {aka ‘int(struct _gckOS *, void *)’}
  341 | _QuerySignal(gckOS Os, gctSIGNAL Signal);
      | ^~~~~~~~~~~~

```